### PR TITLE
Fix for webpack 4 retaining backward compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,12 @@ class WildcardsEntryWebpackPlugin {
 
     apply(compiler) {
         compiler.plugin("after-compile", function (compilation, callback) {
-            compilation.contextDependencies.add(globBasedir);
+            if (Array.isArray(compilation.contextDependencies)) {
+                compilation.contextDependencies.push(globBasedir);
+            }
+            else {
+                compilation.contextDependencies.add(globBasedir);
+            }
             callback();
         });
     }


### PR DESCRIPTION
This is an alternative fix for webpack 4 compatibility, one that retain backward compatibility ensuring it can still be used with older versions 